### PR TITLE
Script improvement

### DIFF
--- a/genstrings_merge.py
+++ b/genstrings_merge.py
@@ -8,7 +8,7 @@ OUTPUT_FILE = 'Localizable.strings'
 OUTPUT_ENCODING = 'utf-16'
 OUTPUT_LINE_PATTERN = u'/* {comment} */\n"{key}" = "{value}";\n\n'
 
-pattern = re.compile('/\* ([^"]*) \*/\s"([^"]*)" = "([^"]*)";')
+pattern = re.compile(r'/\* ([^"]*) \*/\s"([^"]*)" = "((?:\\.|[^"\\])*)";')
 String = namedtuple('String', ['key', 'value', 'comment'])
 
 

--- a/genstrings_swift.py
+++ b/genstrings_swift.py
@@ -22,7 +22,7 @@ String = namedtuple('String', ['key', 'value', 'comment'])
 def read_cmd():
     parser = argparse.ArgumentParser()
     parser.add_argument('-o', '--output', help='Command output directory', default='.')
-    parser.add_argument('filepath', help='file to generate strings from')
+    parser.add_argument('filepaths', help='file(s) to generate strings from', type=argparse.FileType('r'), nargs='+')
     args = parser.parse_args()
     return args
 
@@ -62,14 +62,15 @@ def generate_string(params):
     return String(key, value, comment)
 
 
-def grep_file(filepath):
+def grep_file(filepaths):
     strings = []
-    with io.open(filepath, encoding='utf-8') as fp:
-        content = fp.read()
-        for match in string_pattern.finditer(content):
-            params = match.group(1)
-            string = generate_string(params)
-            strings.append(string)
+    for filepath in filepaths:
+        with io.open(filepath.name, encoding='utf-8') as fp:
+			content = fp.read()
+			for match in string_pattern.finditer(content):
+				params = match.group(1)
+				string = generate_string(params)
+				strings.append(string)
     return strings
 
 
@@ -82,7 +83,7 @@ def save_strings(output_dir, strings):
 
 def main():
     args = read_cmd()
-    strings = grep_file(args.filepath)
+    strings = grep_file(args.filepaths)
     save_strings(args.output, strings)
 
 


### PR DESCRIPTION
1. Update the python script for generating the string file from swift source.
   Now, it supports generating string from multiple inputs. The usage is
   similar to the Apple's genstrings tool.
   Usage: find /path/to/source -iname "*.swift" | xargs python ./genstrings_swift.py -o ./App/en.lproj/ ./App/Source/LocalizationConstants.swift
2. Fix the bug in python script for merging the string file. When the string
   value contains escaped double quotes, it will be excluded from the string
   file. For example, following lines will be striped from the final output
   /\* String with quotes */
   "EscapedQuotes" = "\"String with quotes\"";
